### PR TITLE
eliminate deprecation warning on escapes by using raw string

### DIFF
--- a/scripts/check_rosdep.py
+++ b/scripts/check_rosdep.py
@@ -79,7 +79,7 @@ def generic_parser(buf, cb):
         if re.search(r'^\s*#', l) is not None:
             continue
         try:
-            s = re.search(r'(?!' + indent_atom + ')[^\s]', l).start()
+            s = re.search(r'(?!' + indent_atom + r')[^\s]', l).start()
         except:
             print_err("line %u: %s" % (i, l))
             raise


### PR DESCRIPTION
see e.g. https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d